### PR TITLE
fixed callbackUrl

### DIFF
--- a/order/views.py
+++ b/order/views.py
@@ -96,7 +96,7 @@ def payment(request):
         'currency': 'TRY',
         'basketId': 'B67832',
         'paymentGroup': 'PRODUCT',
-        "callbackUrl": "http://127.0.0.1:8000/result/",
+        "callbackUrl": "http://127.0.0.1:8000/order/result/",
         "enabledInstallments": ['2', '3', '6', '9'],
         'buyer': buyer,
         'shippingAddress': address,


### PR DESCRIPTION
order app'in içerisindeki views.py dosyasında 99. satırda Doğru yönlendirme yapılmadığı için csrf hatası veriyor. CallbackUrl düzeltildiğinde hata düzeliyor.